### PR TITLE
Fix a mistake in cbits and add section to README for hlint

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -1,0 +1,17 @@
+- package:
+  - name: ghc-lib-parser-ex
+  - section:
+    - name: library
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        - ghc
+        - ghc-boot-th
+  - section:
+    - name: test:ghc-lib-parser-ex-test
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        - ghc
+        - ghc-boot-th
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ stack runhaskell --package extra --package optparse-applicative CI.hs
 ```
 Run `stack runhaskell --package extra --package optparse-applicative CI.hs -- --help` for more configurability options.
 
+To run [`hlint`](https://github.com/ndmitchell/hlint) on this repository, a suitable command is `hlint --cpp-include cbits' '--cpp-define GHCLIB_API_XXX .` (where `XXX` at this time is one of `808`, `810` or `811`).
+
 ## Releasing `ghc-lib` (notes for maintainers)
 
 Build `ghc-lib-parser-ex` using the [above instructions](#building-ghc-lib-parser-ex)  and upload the resulting `.tar.gz` files to [Hackage](https://hackage.haskell.org/upload).

--- a/cbits/ghclib_api.h
+++ b/cbits/ghclib_api.h
@@ -6,7 +6,7 @@ reserved. SPDX-License-Identifier: BSD-3-Clause.
 #if !defined(GHCLIB_API_H)
 #  define GHCLIB_API_H
 
-#  if !defined(GHCLIB_API_811) && !defined(GHCLIBAPI_810) && !defined(GHCLIB_API_808)
+#  if !defined(GHCLIB_API_811) && !defined(GHCLIB_API_810) && !defined(GHCLIB_API_808)
 #    if defined(MIN_VERSION_ghc_lib_parser)
 #       if !MIN_VERSION_ghc_lib_parser(1,  0,  0)
 #         define GHCLIB_API_811

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 resolver: lts-14.20
 extra-deps: [ghc-lib-parser-0.20200102]
 ghc-options:
-    "$locals": -Wall -Wno-name-shadowing
+    "$locals": -ddump-to-file -ddump-hi -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
     ghc-lib: true


### PR DESCRIPTION
This is a good `pre-push` commit hook:
```bash
#!/bin/bash

for api in GHCLIB_API_808 GHCLIB_API_810 GHCLIB_API_811
do
  stack exec hlint -- --cpp-include cbits --cpp-define $api .
done

stack exec weeder -- . --build
```