### PR TITLE
Don't patch constraint (for now)

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -124,7 +124,7 @@ buildDist StackOptions {stackYaml, resolver, verbosity, cabalVerbose, ghcOptions
 
     -- Make an sdist of the package and extract it.
     patchVersion version "ghc-lib-parser-ex.cabal"
-    patchConstraint version "ghc-lib-parser-ex.cabal"
+    -- patchConstraint version "ghc-lib-parser-ex.cabal"
     mkTarball pkg_ghclib_parser_ex
     renameDirectory pkg_ghclib_parser_ex "ghc-lib-parser-ex"
     -- cmd "git checkout ghc-lib-parser-ex.cabal"


### PR DESCRIPTION
For now don't patch the ghc-lib-parser version constraint. Rework it so that it is set to what is specified in the `--stack-yaml` file and independent of `--version-tag`.