### PR TITLE
Refactor and take extensions into consideration in dynflags

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,11 @@
 # Changelog for ghc-lib-parser-ex
 
+## 8.8.3.0 released 2020-01-25
+- Change in versioning scheme;
+- New modules:
+  - `Language.Haskell.GhclibParserEx.Config`
+  - `Language.Haskell.GhclibParserEx.DynFlags`
+- `parsePragmasIntoDynFlags` signature change.
+
 ## 8.8.1.20191204, 8.8.2, 0.20200102 released 2020-01-18
 - First releases

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,32 +25,32 @@ strategy:
       image: "macOS-10.14"
       stack: "stack.yaml"
 
-    linux-881-881:
+    linux-881-88:
       image: "Ubuntu 16.04"
       stack: "stack-808-808-ghc-lib.yaml"
-    windows-881-881:
+    windows-881-88:
       image: "vs2017-win2016"
       stack: "stack-808-808-ghc-lib.yaml"
-    mac-881-881:
+    mac-881-88:
       image: "macOS-10.14"
       stack: "stack-808-808-ghc-lib.yaml"
     linux-881-881-da:
       image: "Ubuntu 16.04"
       stack: "stack-da-8.8.1.20200122.yaml"
-    windows-881-881-da:
+    windows-881-88-da:
       image: "vs2017-win2016"
       stack: "stack-da-8.8.1.20200122.yaml"
-    mac-881-881-da:
+    mac-881-881-881-da:
       image: "macOS-10.14"
       stack: "stack-da-8.8.1.20200122.yaml"
 
-    linux-881-881-no-ghc-lib:
+    linux-881-88-no-ghc-lib:
       image: "Ubuntu 16.04"
       stack: "stack-808-808-no-ghc-lib.yaml"
-    windows-881-881-no-ghc-lib:
+    windows-881-88-no-ghc-lib:
       image: "vs2017-win2016"
       stack: "stack-808-808-no-ghc-lib.yaml"
-    mac-881-881-no-ghc-lib:
+    mac-881-88-no-ghc-lib:
       image: "macOS-10.14"
       stack: "stack-808-808-no-ghc-lib.yaml"
 

--- a/ghc-lib-parser-ex.cabal
+++ b/ghc-lib-parser-ex.cabal
@@ -29,6 +29,8 @@ flag ghc-lib
 
 library
   exposed-modules:
+      Language.Haskell.GhclibParserEx.Config
+      Language.Haskell.GhclibParserEx.DynFlags
       Language.Haskell.GhclibParserEx.Parse
       Language.Haskell.GhclibParserEx.Outputable
       Language.Haskell.GhclibParserEx.Dump

--- a/src/Language/Haskell/GhclibParserEx/Config.hs
+++ b/src/Language/Haskell/GhclibParserEx/Config.hs
@@ -1,0 +1,75 @@
+-- Copyright (c) 2020, Shayne Fletcher. All rights reserved.
+-- SPDX-License-Identifier: BSD-3-Clause.
+
+{-# OPTIONS_GHC -Wno-missing-fields #-}
+{-# LANGUAGE CPP #-}
+#include "ghclib_api.h"
+
+module Language.Haskell.GhclibParserEx.Config(
+    fakeSettings
+  , fakeLlvmConfig
+  )
+  where
+
+import Config
+import DynFlags
+import Fingerprint
+
+#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
+import GHC.Platform
+import ToolSettings
+#else
+import Platform
+#endif
+
+fakeSettings :: Settings
+fakeSettings = Settings
+#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
+  { sGhcNameVersion=ghcNameVersion
+  , sFileSettings=fileSettings
+  , sTargetPlatform=platform
+  , sPlatformMisc=platformMisc
+  , sPlatformConstants=platformConstants
+  , sToolSettings=toolSettings
+  }
+#else
+  { sTargetPlatform=platform
+  , sPlatformConstants=platformConstants
+  , sProjectVersion=cProjectVersion
+  , sProgramName="ghc"
+  , sOpt_P_fingerprint=fingerprint0
+  }
+#endif
+  where
+#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
+    toolSettings = ToolSettings {
+      toolSettings_opt_P_fingerprint=fingerprint0
+      }
+    fileSettings = FileSettings {}
+    platformMisc = PlatformMisc {}
+    ghcNameVersion =
+      GhcNameVersion{ghcNameVersion_programName="ghc"
+                    ,ghcNameVersion_projectVersion=cProjectVersion
+                    }
+#endif
+    platform =
+      Platform{
+#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
+        platformWordSize = PW8
+      , platformMini = PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
+#else
+        platformWordSize=8
+      , platformOS=OSUnknown
+#endif
+      , platformUnregisterised=True
+      }
+    platformConstants =
+      PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
+
+#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
+fakeLlvmConfig :: LlvmConfig
+fakeLlvmConfig = LlvmConfig [] []
+#else
+fakeLlvmConfig :: (LlvmTargets, LlvmPasses)
+fakeLlvmConfig = ([], [])
+#endif

--- a/src/Language/Haskell/GhclibParserEx/DynFlags.hs
+++ b/src/Language/Haskell/GhclibParserEx/DynFlags.hs
@@ -1,0 +1,32 @@
+-- Copyright (c) 2020, Shayne Fletcher. All rights reserved.
+-- SPDX-License-Identifier: BSD-3-Clause.
+
+module Language.Haskell.GhclibParserEx.DynFlags(
+    parsePragmasIntoDynFlags
+  ) where
+
+import DynFlags
+import Panic
+import HeaderInfo
+import StringBuffer
+import HscTypes
+import GHC.LanguageExtensions.Type
+import Data.List
+
+parsePragmasIntoDynFlags :: DynFlags
+                         -> ([Extension], [Extension])
+                         -> FilePath
+                         -> String
+                         -> IO (Either String DynFlags)
+parsePragmasIntoDynFlags flags (enable, disable) file str =
+  catchErrors $ do
+    let opts = getOptions flags (stringToStringBuffer str) file
+    (flags, _, _) <- parseDynamicFilePragma flags opts
+    let flags' =  foldl' xopt_set flags enable
+    let flags'' = foldl' xopt_unset flags' disable
+    return $ Right (flags'' `gopt_set` Opt_KeepRawTokenStream)
+  where
+    catchErrors :: IO (Either String DynFlags) -> IO (Either String DynFlags)
+    catchErrors act = handleGhcException reportErr
+                        (handleSourceError reportErr act)
+    reportErr e = return $ Left (show e)

--- a/src/Language/Haskell/GhclibParserEx/Parse.hs
+++ b/src/Language/Haskell/GhclibParserEx/Parse.hs
@@ -6,10 +6,7 @@
 #include "ghclib_api.h"
 
 module Language.Haskell.GhclibParserEx.Parse(
-    fakeSettings
-  , fakeLlvmConfig
-  , parsePragmasIntoDynFlags
-  , parseFile
+    parseFile
   , parseModule
   , parseSignature
   , parseImport
@@ -33,79 +30,15 @@ import RdrHsSyn
 #else
 import HsSyn
 #endif
-import Config
 import DynFlags
 import StringBuffer
-import Fingerprint
 import Lexer
 import qualified Parser
 import FastString
 import SrcLoc
-import Panic
-import HscTypes
-import HeaderInfo
 import BkpSyn
 import PackageConfig
 import RdrName
-
-#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
-import GHC.Platform
-import ToolSettings
-#else
-import Platform
-#endif
-
-fakeSettings :: Settings
-fakeSettings = Settings
-#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
-  { sGhcNameVersion=ghcNameVersion
-  , sFileSettings=fileSettings
-  , sTargetPlatform=platform
-  , sPlatformMisc=platformMisc
-  , sPlatformConstants=platformConstants
-  , sToolSettings=toolSettings
-  }
-#else
-  { sTargetPlatform=platform
-  , sPlatformConstants=platformConstants
-  , sProjectVersion=cProjectVersion
-  , sProgramName="ghc"
-  , sOpt_P_fingerprint=fingerprint0
-  }
-#endif
-  where
-#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
-    toolSettings = ToolSettings {
-      toolSettings_opt_P_fingerprint=fingerprint0
-      }
-    fileSettings = FileSettings {}
-    platformMisc = PlatformMisc {}
-    ghcNameVersion =
-      GhcNameVersion{ghcNameVersion_programName="ghc"
-                    ,ghcNameVersion_projectVersion=cProjectVersion
-                    }
-#endif
-    platform =
-      Platform{
-#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
-        platformWordSize = PW8
-      , platformMini = PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
-#else
-        platformWordSize=8
-      , platformOS=OSUnknown
-#endif
-      , platformUnregisterised=True
-      }
-    platformConstants =
-      PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
-
-#if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
-fakeLlvmConfig :: LlvmConfig
-fakeLlvmConfig = LlvmConfig [] []
-#else
-fakeLlvmConfig :: (LlvmTargets, LlvmPasses)
-fakeLlvmConfig = ([], [])
-#endif
 
 parse :: P a -> String -> DynFlags -> ParseResult a
 parse p str flags =
@@ -175,18 +108,3 @@ parseFile filename flags str =
     location = mkRealSrcLoc (mkFastString filename) 1 1
     buffer = stringToStringBuffer str
     parseState = mkPState flags buffer location
-
-parsePragmasIntoDynFlags :: DynFlags
-                         -> FilePath
-                         -> String
-                         -> IO (Either String DynFlags)
-parsePragmasIntoDynFlags flags file str =
-  catchErrors $ do
-    let opts = getOptions flags (stringToStringBuffer str) file
-    (flags, _, _) <- parseDynamicFilePragma flags opts
-    return $ Right (flags `gopt_set` Opt_KeepRawTokenStream)
-  where
-    catchErrors :: IO (Either String DynFlags) -> IO (Either String DynFlags)
-    catchErrors act = handleGhcException reportErr
-                        (handleSourceError reportErr act)
-    reportErr e = return $ Left (show e)

--- a/stack-808-808-ghc-lib.yaml
+++ b/stack-808-808-ghc-lib.yaml
@@ -1,5 +1,5 @@
 resolver: nightly-2020-01-08 # ghc-8.8.1
-extra-deps: [ghc-lib-parser-8.8.1.20191204] # ghc-lib-parser-8.8.1
+extra-deps: [ghc-lib-parser-8.8.2]
 ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -13,6 +13,8 @@ import qualified System.FilePath as FilePath
 import System.IO.Extra
 import Control.Monad
 
+import Language.Haskell.GhclibParserEx.Config
+import Language.Haskell.GhclibParserEx.DynFlags
 import Language.Haskell.GhclibParserEx.Parse
 import Language.Haskell.GhclibParserEx.Dump
 import Language.Haskell.GhclibParserEx.Fixity
@@ -97,7 +99,7 @@ parseTests = testGroup "Parse tests"
         , "readMany = unfoldr $ listToMaybe . concatMap reads . tails"
         ]
       s <- readFile' foo
-      parsePragmasIntoDynFlags flags foo s >>= \case
+      parsePragmasIntoDynFlags flags ([], []) foo s >>= \case
         Left msg -> assertFailure msg
         Right flags -> chkParseResult report flags $ parseFile foo flags s
   ]


### PR DESCRIPTION
New modules `Config` and `DynFlags`; move some functions out of `Parse`;
Change signature of `parsePragmasIntoDynFlags` to take enabling/disabling extensions into account.