### PR TITLE
Only reimplement showAstData for 8.8 builds

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,5 +1,5 @@
 - extensions:
   - default: false
   - name: [CPP, LambdaCase, NamedFieldPuns, ViewPatterns]
-  - {name: GeneralizedNewtypeDeriving, within: [Language.Haskell.GhclibParserEx.HsExtendInstances]}
+  - {name: GeneralizedNewtypeDeriving, within: [Language.Haskell.GhclibParserEx.GHC.Hs.ExtendInstances]}
   - {name: TupleSections, within: [Language.Haskell.GhclibParserEx.Fixity]}

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -7,6 +7,7 @@
       - depends:
         - ghc
         - ghc-boot-th
+        - bytestring
   - section:
     - name: test:ghc-lib-parser-ex-test
     - message:
@@ -14,4 +15,3 @@
       - depends:
         - ghc
         - ghc-boot-th
-

--- a/src/Language/Haskell/GhclibParserEx/Dump.hs
+++ b/src/Language/Haskell/GhclibParserEx/Dump.hs
@@ -1,19 +1,6 @@
 -- Copyright (c) 2020, Shayne Fletcher. All rights reserved.
 -- SPDX-License-Identifier: BSD-3-Clause.
 {-
-Currently 'showAstData' is only available in ghc-lib. I intend to
-move it to ghc-lib-parser. Then, we'll be able to get at it with
-something like,
-
-  #if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
-    import GHC.Hs.Dump
-  #else
-   import HsDumpAst
-   #endif
-
-The implementation is reproduced here until that time.
--}
-{-
 (c) The University of Glasgow 2006
 (c) The GRASP/AQUA Project, Glasgow University, 1992-1998
 -}
@@ -28,6 +15,21 @@ module Language.Haskell.GhclibParserEx.Dump(
   , BlankSrcSpan(..),
 ) where
 
+#if !defined(MIN_VERSION_ghc_lib_parser)
+-- Using native ghc.
+#  if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
+import GHC.Hs.Dump
+#  else
+import HsDumpAst
+#  endif
+#else
+-- Using ghc-lib-parser. Recent versions will include
+-- GHC.Hs.Dump (it got moved in from ghc-lib on 2020-02-05).
+# if defined (GHCLIB_API_811) || defined (GHCLIB_API_810)
+import GHC.Hs.Dump
+#  else
+-- For simplicity, just assume it's missing from 8.8 ghc-lib-parser
+-- builds and reproduce the implementation.
 import Prelude as X hiding ((<>))
 
 import Data.Data hiding (Fixity)
@@ -233,3 +235,5 @@ ext2 :: (Data a, Typeable t)
      -> (forall d1 d2. (Data d1, Data d2) => c (t d1 d2))
      -> c a
 ext2 def ext = maybe def id (dataCast2 ext)
+#  endif
+#endif

--- a/stack-808-808-ghc-lib.yaml
+++ b/stack-808-808-ghc-lib.yaml
@@ -1,5 +1,5 @@
 resolver: nightly-2020-01-25 # ghc-8.8.2
-extra-deps: [ghc-lib-parser-8.8.2]
+extra-deps: [ghc-lib-parser-8.8.2.20200205]
 ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 resolver: lts-14.20 # ghc-8.6.5
-extra-deps: [ghc-lib-parser-0.20200201]
+extra-deps: [ghc-lib-parser-0.20200205]
 ghc-options:
     "$locals": -ddump-to-file -ddump-hi -Wall -Wno-name-shadowing
 flags:


### PR DESCRIPTION
Upgrade to `ghc-lib-parser-0.2020205` and only reimplement `showAstData` if not using native ghc and  on an 8.8 API.