### PR TITLE
Add missing base fixities; add oprhan instance Ord for Extension

### DIFF
--- a/src/Language/Haskell/GhclibParserEx/DynFlags.hs
+++ b/src/Language/Haskell/GhclibParserEx/DynFlags.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: BSD-3-Clause.
 
 {-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wno-orphans #-} -- Yes, I know.
 #include "ghclib_api.h"
 
 module Language.Haskell.GhclibParserEx.DynFlags(
@@ -29,7 +30,13 @@ import GHC.LanguageExtensions.Type
 import Data.List
 import Data.List.Extra
 import Data.Maybe
+import Data.Function
 import qualified Data.Map as Map
+
+-- Oprhan instance until
+-- https://gitlab.haskell.org/ghc/ghc/merge_requests/2707 lands.
+instance Ord Extension where
+  compare = compare `on` fromEnum
 
 -- | Parse a GHC extension.
 readExtension :: String -> Maybe Extension

--- a/src/Language/Haskell/GhclibParserEx/Fixity.hs
+++ b/src/Language/Haskell/GhclibParserEx/Fixity.hs
@@ -150,16 +150,18 @@ preludeFixities = concat
 -- this list is that of Control.Arrows.
 baseFixities :: [(String, Fixity)]
 baseFixities = preludeFixities ++ concat
-    [ infixl_ 9 ["!","//","!:"]
+    [ infixr_ 9 ["Compose"]
+    , infixl_ 9 ["!","//","!:"]
     , infixl_ 8 ["shift","rotate","shiftL","shiftR","rotateL","rotateR"]
     , infixl_ 7 [".&."]
     , infixl_ 6 ["xor"]
     , infix_  6 [":+"]
+    , infixr_ 6 ["<>"]
     , infixl_ 5 [".|."]
-    , infixr_ 5 ["+:+","<++","<+>"] -- Fixity conflict for +++ between ReadP and Arrow.
+    , infixr_ 5 ["+:+","<++","<+>","<|"] -- Fixity conflict for +++ between ReadP and Arrow.
     , infix_  5 ["\\\\"]
-    , infixl_ 4 ["<$>","<$","<*>","<*","*>","<**>"]
-    , infix_  4 ["elemP","notElemP"]
+    , infixl_ 4 ["<$>","<$","$>","<*>","<*","*>","<**>","<$!>"]
+    , infix_  4 ["elemP","notElemP",":~:", ":~~:"]
     , infixl_ 3 ["<|>"]
     , infixr_ 3 ["&&&","***"]
     , infixr_ 2 ["+++","|||"]


### PR DESCRIPTION
- Add missing fixities (see https://github.com/ndmitchell/hlint/issues/913)
- Give `Extension` an `Ord` instance (see https://github.com/ndmitchell/hlint/pull/912#discussion_r392924459 and https://gitlab.haskell.org/ghc/ghc/merge_requests/2707).