### PR TITLE
Fix ghc-lib cabal flag logic

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,8 +66,9 @@ steps:
     displayName: Install brew
 
   - script: |
-      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s . '--cpp-include cbits' '--cpp-define GHCLIB_API_808'
-      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s . '--cpp-include cbits' '--cpp-define GHCLIB_API_811'
       curl -sSL https://get.haskellstack.org/ | sh
       stack --stack-yaml=$(stack) setup > /dev/null
+      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s . '--cpp-include cbits' '--cpp-define GHCLIB_API_808'
+      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s . '--cpp-include cbits' '--cpp-define GHCLIB_API_810'
+      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s . '--cpp-include cbits' '--cpp-define GHCLIB_API_811'
       stack runhaskell --stack-yaml=$(stack) --package extra --package optparse-applicative CI.hs -- --stack-yaml=$(stack)

--- a/ghc-lib-parser-ex.cabal
+++ b/ghc-lib-parser-ex.cabal
@@ -50,9 +50,10 @@ library
       uniplate >= 1.5,
       bytestring >= 0.10.8.2,
       containers >= 0.5.8.1
-  if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
+  -- Unless explicitly told to link ghc-lib-parser, assume ghc native.
+  if !flag(ghc-lib)
       build-depends:
-        ghc == 8.8.*,
+        ghc,
         ghc-boot-th,
         ghc-boot
   else
@@ -83,9 +84,9 @@ test-suite ghc-lib-parser-ex-test
     , filepath >= 1.4.2
     , extra >=1.6
     , ghc-lib-parser-ex
-  if !flag(ghc-lib) && impl(ghc >= 8.8.0) && impl(ghc < 8.9.0)
+  if !flag(ghc-lib) && impl(ghc >= 8.10.0) && impl(ghc < 8.11.0)
       build-depends:
-        ghc == 8.8.*,
+        ghc == 8.10.*,
         ghc-boot-th
   else
       build-depends:

--- a/src/Language/Haskell/GhclibParserEx/GHC/Hs/Pat.hs
+++ b/src/Language/Haskell/GhclibParserEx/GHC/Hs/Pat.hs
@@ -56,7 +56,7 @@ fromPChar (dL -> L _ (LitPat _ (HsChar _ x))) = Just x
 fromPChar _ = Nothing
 
 -- Contains a '..' as in 'Foo{..}'
-hasPFieldsDotDot :: HsRecFields GhcPs (Pat GhcPs) -> Bool
+hasPFieldsDotDot :: HsRecFields GhcPs (LPat GhcPs) -> Bool
 hasPFieldsDotDot HsRecFields {rec_dotdot=Just _} = True
 hasPFieldsDotDot _ = False
 

--- a/stack-808-808-ghc-lib.yaml
+++ b/stack-808-808-ghc-lib.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-03-14 # ghc-8.8.3
+resolver: nightly-2020-01-25 # ghc-8.8.2
 extra-deps:
   - ghc-lib-parser-8.8.3.20200224
   - extra-1.7.1

--- a/stack-810-808-no-ghc-lib.yaml
+++ b/stack-810-808-no-ghc-lib.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-03-24 # ghc-8.8.3
+resolver: nightly-2020-01-25 # ghc-8.8.2
 extra-deps:
   - extra-1.7.1
 ghc-options:


### PR DESCRIPTION
We shouldn't be constrained by the ghc version when deciding if ghc native libs should be linked or not. By default we assume ghc-lib native unless explicitly told otherwise.