### PR TITLE
Introduce no-ghc-lib flag

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -9,6 +9,7 @@
         - ghc-boot-th
         - ghc-boot
         - bytestring
+        - ghc-lib-parser
   - section:
     - name: test:ghc-lib-parser-ex-test
     - message:
@@ -16,3 +17,4 @@
       - depends:
         - ghc
         - ghc-boot-th
+        - ghc-lib-parser

--- a/ghc-lib-parser-ex.cabal
+++ b/ghc-lib-parser-ex.cabal
@@ -22,10 +22,10 @@ source-repository head
   type: git
   location: https://github.com/shayne-fletcher/ghc-lib-parser-ex
 
-flag ghc-lib
+flag no-ghc-lib
   default: False
   manual: True
-  description: Force dependency on ghc-lib-parser even if GHC API in the ghc package is supported
+  description: Force dependency on native ghc-libs
 
 library
   exposed-modules:
@@ -50,15 +50,14 @@ library
       uniplate >= 1.5,
       bytestring >= 0.10.8.2,
       containers >= 0.5.8.1
-  -- Unless explicitly told to link ghc-lib-parser, assume ghc native.
-  if !flag(ghc-lib)
-      build-depends:
-        ghc,
-        ghc-boot-th,
-        ghc-boot
+  if flag(no-ghc-lib)
+    build-depends:
+      ghc,
+      ghc-boot-th,
+      ghc-boot
   else
-      build-depends:
-        ghc-lib-parser
+    build-depends:
+      ghc-lib-parser
   include-dirs:
       cbits
   install-includes:
@@ -84,9 +83,9 @@ test-suite ghc-lib-parser-ex-test
     , filepath >= 1.4.2
     , extra >=1.6
     , ghc-lib-parser-ex
-  if !flag(ghc-lib) && impl(ghc >= 8.10.0) && impl(ghc < 8.11.0)
+  if flag(no-ghc-lib)
       build-depends:
-        ghc == 8.10.*,
+        ghc,
         ghc-boot-th
   else
       build-depends:

--- a/stack-0.20200102.yaml
+++ b/stack-0.20200102.yaml
@@ -4,7 +4,7 @@ ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
-    ghc-lib: true
+    no-ghc-lib: false
 
 # Packages MUST go at the end, since we append to it during execution
 # of CI.hs.

--- a/stack-8.8.1.20191204.yaml
+++ b/stack-8.8.1.20191204.yaml
@@ -6,7 +6,7 @@ ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
-    ghc-lib: true
+    no-ghc-lib: false
 
 # Packages MUST go at the end, since we append to it during execution
 # of CI.hs.

--- a/stack-808-808-ghc-lib.yaml
+++ b/stack-808-808-ghc-lib.yaml
@@ -6,7 +6,7 @@ ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
-    ghc-lib: true
+    no-ghc-lib: false
 
 # Packages MUST go at the end, since we append to it during execution
 # of CI.hs.

--- a/stack-808-808-no-ghc-lib.yaml
+++ b/stack-808-808-no-ghc-lib.yaml
@@ -5,7 +5,7 @@ ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
-    ghc-lib: false
+    no-ghc-lib: true
 
 # Packages MUST go at the end, since we append to it during execution
 # of CI.hs.

--- a/stack-810-808-ghc-lib.yaml
+++ b/stack-810-808-ghc-lib.yaml
@@ -6,7 +6,7 @@ ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
-    ghc-lib: true
+    no-ghc-lib: false
 
 # Packages MUST go at the end, since we append to it during execution
 # of CI.hs.

--- a/stack-810-808-no-ghc-lib.yaml
+++ b/stack-810-808-no-ghc-lib.yaml
@@ -5,7 +5,7 @@ ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
-    ghc-lib: true
+    no-ghc-lib: true
 
 # Packages MUST go at the end, since we append to it during execution
 # of CI.hs.

--- a/stack-da-8.8.1.20200122.yaml
+++ b/stack-da-8.8.1.20200122.yaml
@@ -6,7 +6,7 @@ ghc-options:
     "$locals": -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
-    ghc-lib: true
+    no-ghc-lib: false
 
 # Packages MUST go at the end, since we append to it during execution
 # of CI.hs.

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ ghc-options:
     "$locals": -ddump-to-file -ddump-hi -Wall -Wno-name-shadowing
 flags:
   ghc-lib-parser-ex:
-    ghc-lib: true
+    no-ghc-lib: false
 
 # Packages MUST go at the end, since we append to it during execution
 # of CI.hs.


### PR DESCRIPTION
Change the logic of the cabal flags so that it is assumed you want to link ghc-lib-parser unless told otherwise