### PR TITLE
Remove >= from cabal-version

### DIFF
--- a/ghc-lib-parser-ex.cabal
+++ b/ghc-lib-parser-ex.cabal
@@ -1,4 +1,4 @@
-cabal-version: >= 1.18
+cabal-version:  1.18
 name:           ghc-lib-parser-ex
 version:        0.1.0
 description:    Please see the README on GitHub at <https://github.com/shayne-fletcher/ghc-lib-parser-ex#readme>


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: ghc-lib-parser-ex.cabal:1:23: Packages with 'cabal-version: 1.12' or                                                                                                                                                                                                      
later should specify a specific version of the Cabal spec of the form                                                                                                                                                                                                              
'cabal-version: x.y'. Use 'cabal-version: 1.18'.                                                                                                                                                                                                                                   
```