### PR TITLE
Implement isMonadComp, isListComp

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for ghc-lib-parser-ex
 
+## Unreleased
+- Added to `GhclibParserEx.GHC.Hs.Expr`:
+  - `isMonadComp`
+  - `isListComp`
+
 ## 0.20210701 released 2021-07-01
 - Update to `ghc-lib-0.20210701`
 

--- a/src/Language/Haskell/GhclibParserEx/GHC/Hs/Expr.hs
+++ b/src/Language/Haskell/GhclibParserEx/GHC/Hs/Expr.hs
@@ -9,7 +9,7 @@ module Language.Haskell.GhclibParserEx.GHC.Hs.Expr(
   isTag, isDol, isDot, isReturn, isSection, isRecConstr, isRecUpdate,
   isVar, isPar, isApp, isOpApp, isAnyApp, isLexeme, isLambda, isQuasiQuote,
   isDotApp, isTypeApp, isWHNF, isLCase,
-  isFieldPun, isFieldPunUpdate, isRecStmt, isParComp, isMDo, isTupleSection, isString, isPrimLiteral,
+  isFieldPun, isFieldPunUpdate, isRecStmt, isParComp, isMDo, isListComp, isMonadComp, isTupleSection, isString, isPrimLiteral,
   isSpliceDecl, isFieldWildcard, isUnboxed, isWholeFrac, isStrictMatch, isMultiIf, isProc, isTransStmt,
   hasFieldsDotDot,
   varToStr, strToVar,
@@ -117,12 +117,21 @@ isRecStmt = \case RecStmt{} -> True; _ -> False
 isParComp :: StmtLR GhcPs GhcPs (LHsExpr GhcPs) -> Bool
 isParComp = \case ParStmt{} -> True; _ -> False
 
+-- TODO: Seems `HsStmtContext (HsDoRn p)` on master right now.
 #if defined (GHCLIB_API_HEAD) || defined(GHCLIB_API_902) || defined (GHCLIB_API_900)
 isMDo :: HsStmtContext GhcRn -> Bool
 isMDo = \case MDoExpr _ -> True; _ -> False
+isMonadComp :: HsStmtContext GhcRn -> Bool
+isMonadComp = \case MonadComp -> True; _ -> False
+isListComp :: HsStmtContext GhcRn -> Bool
+isListComp = \case ListComp -> True; _ -> False
 #else
 isMDo :: HsStmtContext Name -> Bool
 isMDo = \case MDoExpr -> True; _ -> False
+isMonadComp :: HsStmtContext Name -> Bool
+isMonadComp = \case MonadComp -> True; _ -> False
+isListComp :: HsStmtContext Name -> Bool
+isListComp = \case ListComp -> True; _ -> False
 #endif
 
 isTupleSection :: HsTupArg GhcPs -> Bool


### PR DESCRIPTION
Similar to `isMDo` which can be used to determine if `RecursiveDo` is in use, `isMonadComp` will return `True` if a parse tree contains an `HsDo` `HsStmtContext` that is of case `MonadComp` (It's all or nothing: if `MonadComprehensions` are enabled all statement contexts will be `MonadComp`; if it's not all statement contexts will be of case `ListComp`.)

See https://github.com/ndmitchell/hlint/issues/1261 where the utility of this predicate is motivated.