### PR TITLE
HsExpr's OpApp remove unused annotation

### DIFF
--- a/src/Language/Haskell/GhclibParserEx/Fixity.hs
+++ b/src/Language/Haskell/GhclibParserEx/Fixity.hs
@@ -155,9 +155,14 @@ mkOpApp ::
    -> LHsExpr GhcPs
 --      (e11 `op1` e12) `op2` e2
 mkOpApp fs loc e1@(L _ (OpApp x1 e11 op1 e12)) op2 fix2 e2
-#if ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
+# if ! (defined (GHC_9_10) || defined (GHC_9_8) || defined (GHC_9_6) || defined (GHC_9_4) || defined (GHC_9_2) || defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8) )
+-- ghc > 9.10
+  | nofix_error = L loc (OpApp noExtField e1 op2 e2)
+#elif ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
+-- ghc > 9.0
   | nofix_error = L loc (OpApp noAnn e1 op2 e2)
 #else
+-- otherwise
   | nofix_error = L loc (OpApp noExt e1 op2 e2)
 #endif
   | associate_right = L loc (OpApp x1 e11 op1 (mkOpApp fs loc' e12 op2 fix2 e2 ))
@@ -171,9 +176,14 @@ mkOpApp fs loc e1@(L _ (OpApp x1 e11 op1 e12)) op2 fix2 e2
     (nofix_error, associate_right) = compareFixity fix1 fix2
 --      (- neg_arg) `op` e2
 mkOpApp fs loc e1@(L _ (NegApp _ neg_arg neg_name)) op2 fix2 e2
-#if ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
+# if ! (defined (GHC_9_10) || defined (GHC_9_8) || defined (GHC_9_6) || defined (GHC_9_4) || defined (GHC_9_2) || defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8) )
+-- ghc > 9.10
+  | nofix_error = L loc (OpApp noExtField e1 op2 e2)
+#elif ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
+-- ghc > 9.0
   | nofix_error = L loc (OpApp noAnn e1 op2 e2)
 #else
+-- otherwise
   | nofix_error = L loc (OpApp noExt e1 op2 e2)
 #endif
 #if ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
@@ -190,7 +200,10 @@ mkOpApp fs loc e1@(L _ (NegApp _ neg_arg neg_name)) op2 fix2 e2
     (nofix_error, associate_right) = compareFixity negateFixity fix2
 --      e1 `op` - neg_arg
 mkOpApp _ loc e1 op1 fix1 e2@(L _ NegApp {}) -- NegApp can occur on the right.
-#if ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
+# if ! (defined (GHC_9_10) || defined (GHC_9_8) || defined (GHC_9_6) || defined (GHC_9_4) || defined (GHC_9_2) || defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8) )
+-- ghc > 9.10
+  | not associate_right  = L loc (OpApp noExtField e1 op1 e2)-- We *want* right association.
+#elif ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
   | not associate_right  = L loc (OpApp noAnn e1 op1 e2)-- We *want* right association.
 #else
   | not associate_right  = L loc (OpApp noExt e1 op1 e2)-- We *want* right association.
@@ -198,7 +211,10 @@ mkOpApp _ loc e1 op1 fix1 e2@(L _ NegApp {}) -- NegApp can occur on the right.
   where
     (_, associate_right) = compareFixity fix1 negateFixity
  --     Default case, no rearrangment.
-#if ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
+# if ! (defined (GHC_9_10) || defined (GHC_9_8) || defined (GHC_9_6) || defined (GHC_9_4) || defined (GHC_9_2) || defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8) )
+-- ghc > 9.10
+mkOpApp _ loc e1 op _fix e2 = L loc (OpApp noExtField e1 op e2)
+#elif ! (defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8))
 mkOpApp _ loc e1 op _fix e2 = L loc (OpApp noAnn e1 op e2)
 #else
 mkOpApp _ loc e1 op _fix e2 = L loc (OpApp noExt e1 op e2)


### PR DESCRIPTION
follow on from https://gitlab.haskell.org/ghc/ghc/-/commit/ef481813719c5f6d9d97b60ffef4617307d24c80