### PR TITLE
Fix isLCase to also match LamCases

### DIFF
--- a/src/Language/Haskell/GhclibParserEx/GHC/Hs/Expr.hs
+++ b/src/Language/Haskell/GhclibParserEx/GHC/Hs/Expr.hs
@@ -129,7 +129,7 @@ isWHNF = \case
     | occNameString (rdrNameOcc x) `elem` ["Just", "Left", "Right"] -> True
   _ -> False
 #if ! ( defined (GHC_9_8) || defined (GHC_9_6) || defined (GHC_9_4) || defined (GHC_9_2) || defined (GHC_9_0) || defined (GHC_8_10) || defined (GHC_8_8) )
-isLCase = \case (L _ (HsLam _ LamCase _)) -> True; _ -> False
+isLCase = \case (L _ (HsLam _ LamCase _)) -> True; (L _ (HsLam _ LamCases _)) -> True; _ -> False
 #else
 isLCase = \case (L _ HsLamCase{}) -> True; _ -> False
 #endif


### PR DESCRIPTION
This is how this predicate worked historically

Resolves https://github.com/shayne-fletcher/ghc-lib-parser-ex/issues/193